### PR TITLE
Enable compile-only cargo doctests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(unix)']
-runner = 'sudo -E'
+runner = "sudo -E"
 
 [target.'cfg(windows)']
 runner = "powershell -Command Start-Process -Verb runAs -FilePath"

--- a/rscap/Cargo.toml
+++ b/rscap/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/pkts-rs/rscap"
 keywords = ["packets", "capture", "pcap", "libpcap", "npcap", "bpf", "raw_sockets"]
 categories = ["network-programming"]
 
-[lib]
-doctest = false
-
 [features]
 # Enables use of the npcap driver on Windows systems when the necessary dll libraries are present.
 # 

--- a/rscap/src/linux/l3.rs
+++ b/rscap/src/linux/l3.rs
@@ -791,7 +791,8 @@ impl L3MappedSocket {
         self.socket.set_fanout(group_id, fan_alg, defrag, rollover)
     }
 
-    /// Sets `mapped_send` results to be manually handled through repeated calls to `tx_status`.
+    /// Sets [`mapped_send()`](Self::mapped_send) results to be manually handled through repeated
+    /// calls to [`tx_status()`](Self::tx_status).
     ///
     /// By default (i.e., when `manual` = `false`), the results of packet transmission are
     /// transparently handled. As a result, packets flagged as malformed by the kernel are
@@ -799,8 +800,8 @@ impl L3MappedSocket {
     /// basis.
     ///
     /// If individual packet results are desired, setting this option to `true` modifies socket
-    /// behavior such that each sent packet must have its status checked using `tx_status` prior
-    /// to that packet being discarded from the ring.
+    /// behavior such that each sent packet must have its status checked using
+    /// [`tx_status()`](Self::tx_status) prior to that packet being discarded from the ring.
     #[inline]
     pub fn manual_tx_status(&mut self, manual: bool) {
         self.manual_tx_status = manual;


### PR DESCRIPTION
Doctests were disabled in the previous commit due to issues with determining how to run them as privileged operations. This PR adds the `no_run` option to documentation examples to resolve this issue and allow for compile-time checking of documentation examples.