### PR TITLE
Fix incorrect size of req_rx passed to setsockopt

### DIFF
--- a/rscap/src/linux/l2.rs
+++ b/rscap/src/linux/l2.rs
@@ -955,7 +955,7 @@ impl L2Socket {
                 libc::SOL_PACKET,
                 crate::linux::PACKET_RX_RING,
                 ptr::addr_of!(req_rx) as *const libc::c_void,
-                mem::size_of::<crate::linux::tpacket_req>() as u32,
+                mem::size_of_val(&req_rx) as u32,
             ) != 0
         } {
             return Err(io::Error::last_os_error());


### PR DESCRIPTION
It is a tpacket_req3 struct instead of tpacket_req.