### PR TITLE
Npcap thread-safe read; &self for send/recv

### DIFF
--- a/rscap/src/bpf.rs
+++ b/rscap/src/bpf.rs
@@ -95,8 +95,8 @@ impl SnifferImpl {
     }
 
     #[inline]
-    pub fn send(&self, packet: &[u8]) -> io::Result<usize> {
-        self.bpf.send(packet)
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.bpf.send(buf)
     }
 
     #[inline]

--- a/rscap/src/bpf/l2.rs
+++ b/rscap/src/bpf/l2.rs
@@ -522,14 +522,8 @@ impl Bpf {
 
     /// Send a link-layer packet on the interface bound to the given socket.
     #[inline]
-    pub fn send(&self, packet: &[u8]) -> io::Result<usize> {
-        let res = unsafe {
-            libc::write(
-                self.fd,
-                packet.as_ptr() as *const libc::c_void,
-                packet.len(),
-            )
-        };
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        let res = unsafe { libc::write(self.fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
         match res {
             0.. => Ok(res as usize),
             _ => Err(io::Error::last_os_error()),

--- a/rscap/src/linux.rs
+++ b/rscap/src/linux.rs
@@ -450,8 +450,8 @@ impl SnifferImpl {
     }
 
     #[inline]
-    pub fn send(&self, packet: &[u8]) -> io::Result<usize> {
-        self.socket.send(packet)
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.socket.send(buf)
     }
 
     #[inline]

--- a/rscap/src/npcap.rs
+++ b/rscap/src/npcap.rs
@@ -51,7 +51,7 @@ pub(crate) struct SnifferImpl {
 impl SnifferImpl {
     #[inline]
     pub fn new(iface: Interface) -> io::Result<Self> {
-        let mut adapter = NpcapAdapter::new(iface)?;
+        let adapter = NpcapAdapter::new(iface)?;
         adapter.set_filter(&mut PacketFilter::reject_all())?;
 
         Ok(Self { adapter })
@@ -71,7 +71,7 @@ impl SnifferImpl {
     }
 
     #[inline]
-    pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.adapter.set_nonblocking(nonblocking);
         Ok(())
     }
@@ -82,12 +82,12 @@ impl SnifferImpl {
     }
 
     #[inline]
-    pub fn send(&mut self, packet: &[u8]) -> io::Result<usize> {
-        self.adapter.send(packet)
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.adapter.send(buf)
     }
 
     #[inline]
-    pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.adapter.recv(buf)
     }
 }

--- a/rscap/src/npcap/adapter.rs
+++ b/rscap/src/npcap/adapter.rs
@@ -8,92 +8,49 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ffi::CStr;
-use std::io;
-use std::mem::MaybeUninit;
-use std::ptr::{self, NonNull};
-
 use once_cell::sync::OnceCell;
 
 use windows_sys::Win32::Foundation::{ERROR_BAD_UNIT, ERROR_INVALID_NAME, HANDLE};
 use windows_sys::Win32::Networking::WinSock::{WSACleanup, WSAStartup, WSADATA};
 use windows_sys::Win32::System::Threading::{WaitForSingleObject, INFINITE};
 
+use std::cell::UnsafeCell;
+use std::ffi::CStr;
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::{cmp, io, mem, ptr};
+
 use crate::filter::{PacketFilter, PacketStatistics};
 use crate::Interface;
 
-use super::dll::{Adapter, BpfStat, Npcap, Packet};
+use super::dll::{packet_wordalign, Adapter, BpfHdr, BpfStat, Npcap, Packet};
 use super::NpcapTimeout;
 
 const WSA_VERSION: u16 = 0x0202;
 
 static NPCAP_API: OnceCell<Npcap> = OnceCell::new();
 
+pub struct PacketContext {
+    packet: NonNull<Packet>,
+    pktbuf: UnsafeCell<Vec<u8>>,
+    pkt_indices: UnsafeCell<Vec<usize>>,
+    ticket_info: AtomicU64, // <next_ticket> (32 bits) | <ticket_range> (32 bits)
+    outstanding: AtomicUsize, // "E"
+}
+
 /// A network adapter capable of sniffing and injecting packets over an interface.
 pub struct NpcapAdapter {
+    npcap: &'static Npcap,
     adapter: NonNull<Adapter>,
     iface: Interface,
-    nonblocking: bool,
-    npcap: &'static Npcap,
-    packet: NonNull<Packet>,
+    nonblocking: AtomicBool,
+    pkt_ctx: PacketContext,
 }
 
 impl NpcapAdapter {
     pub const DEFAULT_DRIVER_BUFFER: usize = 1024 * 1024; // Default buffer of 1MB (similar to libpcap)
-
-    /// Retrieves the name of the npcap driver.
-    ///
-    /// As Winpcap uses a very similar API to npcap, this function is useful in disambiguating
-    /// the one from the other.
-    #[inline]
-    pub fn driver_name(&self) -> &CStr {
-        unsafe { self.npcap.driver_name() }
-    }
-
-    /// Retrieves the version of the npcap driver.
-    #[inline]
-    pub fn driver_version(&self) -> &CStr {
-        unsafe { self.npcap.driver_version() }
-    }
-
-    /// Retrieves the interface the npcap driver is listening on.
-    #[inline]
-    pub fn interface(&self) -> Interface {
-        self.iface
-    }
-
-    /// Indicates whether monitor mode is enabled for the associated network interface.
-    pub fn monitor_mode(iface: Interface) -> io::Result<bool> {
-        let npcap = NPCAP_API.get_or_try_init(Npcap::new)?;
-
-        match unsafe { npcap.get_monitor_mode(iface.name_cstr()) } {
-            1 => Ok(true),
-            0 => Ok(false),
-            _ => Err(io::Error::last_os_error()),
-        }
-    }
-
-    /// Enables or disables monitor mode for the adapter.
-    ///
-    /// # Errors
-    ///
-    /// On failure, the following error kinds may be returned:
-    /// - [`io::ErrorKind::Unsupported`] - monitor mode is unsupported for the device currrently
-    ///   being captured from.
-    pub fn set_monitor_mode(iface: Interface, enabled: bool) -> io::Result<()> {
-        let npcap = NPCAP_API.get_or_try_init(Npcap::new)?;
-
-        let enabled = match enabled {
-            true => 1,
-            false => 0,
-        };
-
-        match unsafe { npcap.set_monitor_mode(iface.name_cstr(), enabled) } {
-            1 => Ok(()),
-            0 => Err(io::ErrorKind::Unsupported.into()),
-            _ => Err(io::Error::last_os_error()),
-        }
-    }
+    const DEFAULT_PACKET_CAPACITY: usize = 262144;
 
     /// Returns a new Npcap adapter listening on the specified interface.
     ///
@@ -127,6 +84,14 @@ impl NpcapAdapter {
             Some(p) => p,
         };
 
+        let mut pktbuf: Vec<u8> = Vec::with_capacity(Self::DEFAULT_PACKET_CAPACITY);
+        let pktbuf_ptr = NonNull::new(pktbuf.as_mut_ptr()).unwrap();
+
+        // Safety: `init_packet()` is called within a context where exclusive access is guaranteed.
+        unsafe {
+            npcap.init_packet(packet, pktbuf_ptr, Self::DEFAULT_PACKET_CAPACITY);
+        }
+
         let mut wsa_data: MaybeUninit<WSADATA> = MaybeUninit::uninit();
 
         unsafe {
@@ -151,17 +116,77 @@ impl NpcapAdapter {
             Some(p) => p,
         };
 
-        let mut socket = Self {
+        let socket = Self {
             adapter,
             iface,
             npcap,
-            nonblocking: false,
-            packet,
+            nonblocking: AtomicBool::new(false),
+            pkt_ctx: PacketContext {
+                packet,
+                pktbuf: UnsafeCell::new(pktbuf),
+                pkt_indices: UnsafeCell::new(Vec::new()),
+                ticket_info: AtomicU64::new(0),
+                outstanding: AtomicUsize::new(0),
+            },
         };
 
         socket.set_driver_buffer(Self::DEFAULT_DRIVER_BUFFER)?;
 
         Ok(socket)
+    }
+
+    /// Enables or disables monitor mode for the adapter.
+    ///
+    /// # Errors
+    ///
+    /// On failure, the following error kinds may be returned:
+    /// - [`io::ErrorKind::Unsupported`] - monitor mode is unsupported for the device currrently
+    ///   being captured from.
+    pub fn set_monitor_mode(iface: Interface, enabled: bool) -> io::Result<()> {
+        let npcap = NPCAP_API.get_or_try_init(Npcap::new)?;
+
+        let enabled = match enabled {
+            true => 1,
+            false => 0,
+        };
+
+        match unsafe { npcap.set_monitor_mode(iface.name_cstr(), enabled) } {
+            1 => Ok(()),
+            0 => Err(io::ErrorKind::Unsupported.into()),
+            _ => Err(io::Error::last_os_error()),
+        }
+    }
+
+    /// Retrieves the name of the npcap driver.
+    ///
+    /// As Winpcap uses a very similar API to npcap, this function is useful in disambiguating
+    /// the one from the other.
+    #[inline]
+    pub fn driver_name(&self) -> &CStr {
+        unsafe { self.npcap.driver_name() }
+    }
+
+    /// Retrieves the version of the npcap driver.
+    #[inline]
+    pub fn driver_version(&self) -> &CStr {
+        unsafe { self.npcap.driver_version() }
+    }
+
+    /// Retrieves the interface the npcap driver is listening on.
+    #[inline]
+    pub fn interface(&self) -> Interface {
+        self.iface
+    }
+
+    /// Indicates whether monitor mode is enabled for the associated network interface.
+    pub fn monitor_mode(iface: Interface) -> io::Result<bool> {
+        let npcap = NPCAP_API.get_or_try_init(Npcap::new)?;
+
+        match unsafe { npcap.get_monitor_mode(iface.name_cstr()) } {
+            1 => Ok(true),
+            0 => Ok(false),
+            _ => Err(io::Error::last_os_error()),
+        }
     }
 
     /// Sets `filter` as the packet filter for the adapter.
@@ -177,7 +202,7 @@ impl NpcapAdapter {
     /// - [io::ErrorKind::OutOfMemory] - the operating system had insufficent memory to allocate
     /// the packet filter.
     /// - [io::ErrorKind::Other] - some other unexpected error occurred.
-    pub fn set_filter(&mut self, filter: &mut PacketFilter) -> io::Result<()> {
+    pub fn set_filter(&self, filter: &mut PacketFilter) -> io::Result<()> {
         match unsafe { self.npcap.set_bpf(self.adapter, &filter.as_bpf_program()) } {
             false => Err(io::Error::last_os_error()),
             true => Ok(()),
@@ -203,17 +228,14 @@ impl NpcapAdapter {
             return Err(io::Error::new(io::ErrorKind::Other, e));
         }
 
-        let mut tmp_buf = [0u8; 0];
+        // Invalidate all packets currently in the ringbuffer
+        self.pkt_ctx.ticket_info.store(0, Ordering::Release);
+        self.pkt_ctx.outstanding.store(0, Ordering::Release);
 
         // Loop through messages until none left to be received
         loop {
-            let buf = unsafe { NonNull::new_unchecked(tmp_buf.as_mut_ptr()) };
-            unsafe {
-                self.npcap.init_packet(self.packet, buf, 0);
-            }
-
             // This is nonblocking by default
-            match unsafe { self.npcap.receive_packet(self.adapter, self.packet) } {
+            match unsafe { self.npcap.receive_packet(self.adapter, self.pkt_ctx.packet) } {
                 false => break, // TODO: check return value here
                 true => (),
             }
@@ -225,19 +247,19 @@ impl NpcapAdapter {
     /// Configures whether the adapter will perform [`send()`](Self::send)/[`recv()`](Self::recv)
     /// methods in a nonblocking manner.
     #[inline]
-    pub fn set_nonblocking(&mut self, nonblocking: bool) {
-        self.nonblocking = nonblocking;
+    pub fn set_nonblocking(&self, nonblocking: bool) {
+        self.nonblocking.store(nonblocking, Ordering::Relaxed);
     }
 
     /// Indicates whether the adapter will perform [`send()`](Self::send)/[`recv()`](Self::recv)
     /// methods in a nonblocking manner.
     #[inline]
     pub fn nonblocking(&self) -> bool {
-        self.nonblocking
+        self.nonblocking.load(Ordering::Relaxed)
     }
 
     /// Retrieves statistical information on the number of packets the adapter has captured/dropped.
-    pub fn packet_stats(&mut self) -> io::Result<PacketStatistics> {
+    pub fn packet_stats(&self) -> io::Result<PacketStatistics> {
         let mut stat = BpfStat {
             bs_recv: 0,
             bs_drop: 0,
@@ -255,7 +277,7 @@ impl NpcapAdapter {
     }
 
     /// Sets the size of the buffer used by the npcap driver to queue packets for the socket.
-    pub fn set_driver_buffer(&mut self, buffer_size: usize) -> io::Result<()> {
+    pub fn set_driver_buffer(&self, buffer_size: usize) -> io::Result<()> {
         let buffer_size =
             libc::c_int::try_from(buffer_size).map_err(|_| io::ErrorKind::InvalidInput)?;
         match unsafe { self.npcap.set_buff(self.adapter, buffer_size) } {
@@ -265,7 +287,7 @@ impl NpcapAdapter {
     }
 
     /// Defines the minimum amount of data npcap driver that will cause a `recv()` to return.
-    pub fn set_min_to_copy(&mut self, copy_bytes: usize) -> io::Result<()> {
+    pub fn set_min_to_copy(&self, copy_bytes: usize) -> io::Result<()> {
         let copy_bytes =
             libc::c_int::try_from(copy_bytes).map_err(|_| io::ErrorKind::InvalidInput)?;
         match unsafe { self.npcap.set_min_to_copy(self.adapter, copy_bytes) } {
@@ -274,35 +296,208 @@ impl NpcapAdapter {
         }
     }
 
-    pub fn read_event_handle(&mut self) -> HANDLE {
+    pub fn read_event_handle(&self) -> HANDLE {
         unsafe { self.npcap.get_read_event(self.adapter) }
     }
 
     /// Receive a datagram from the socket.
-    pub fn recv(&mut self, packet: &mut [u8]) -> io::Result<usize> {
-        let buf = unsafe { NonNull::new_unchecked(packet.as_mut_ptr()) };
-        unsafe {
-            self.npcap.init_packet(self.packet, buf, packet.len());
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // This method is implemented via a non-trivial number of concurrency operations.
+        // It is advisable not to introduce or shuffle ANY code in this method unless you've
+        // done thorough analysis of the potential concurrency issues that may arise.
+
+        // This implementation is the way it is for three reasons:
+        // 1. We want the `recv()` method to use `&self` so that it can be used in async contexts,
+        //    but `npcap` fundamentally uses memory-mapped buffers as its underlying method of
+        //    transport. Thus, we need a way of handling accesses/updates to the buffer in a
+        //    thread-safe way.
+        // 2. We can't use any synchronization primitives that block. Async runimes offer their
+        //    own version of primitives that are safe to use, but using those would bind this
+        //    function to a specific `async` backend.
+        // 3. We'd ideally like multiple tasks to be able to read packets concurrently when more
+        //    than one is in the receive buffer so that asynchronous `recv()` calls actually lead
+        //    to performance improvement.
+        //
+        // Any proposed changes should adhere to these 3 features.
+
+        // The ticket issuer and range of valid tickets are tightly bound to each other by being
+        // saved in the same AtomicU64. This guarantees no ABA problem in checking if the ticket
+        // is out of range.
+        // `Acquire` Synchronizes all prior writes for `pkt_indices` and `pktbuf`
+        let ticket_info = self
+            .pkt_ctx
+            .ticket_info
+            .fetch_add(1 << 32, Ordering::Acquire);
+        let mut ticket = (ticket_info >> 32) as usize; // first 32 bits
+        let range = (ticket_info & 0xff_ff_ff_ff) as usize; // last 32 bits
+        if ticket >= range {
+            // No more packets are available in the mapped packet buffer--it must be refilled
+
+            // Check to see if all outstanding tickets have completed for the current mapped buffer
+            // TODO: is compare_exchange_weak allowed here?
+            match self.pkt_ctx.outstanding.compare_exchange(
+                0,
+                usize::MAX,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => loop {
+                    // This is to mitigate any kind of "what if the computer counts to 4 billion"
+                    // issue. By immediately clearing the `range` field of ticket_info, we guarantee
+                    // that no future bogus tickets are issued that appear valid due to overflow of
+                    // the `ticket` field. Note that because `ticket` counts in increments of 1 << 32,
+                    // an overflow after this has been called will look like the following:
+                    // 0xffffffff00000000 + 0x0000000100000000 = 0x0000000000000000
+                    // The length field is not affected by the wraparound, so the overflow ticket
+                    // will still be correctly identified as out of range.
+                    //
+                    // With this mitigation in place, the only way an invalid ticket could be
+                    // issued is if 2^32 (~4 billion) tickets are issued between the time the
+                    // last valid ticket was issued and the time that task finished copying its
+                    // packet into `buf` (and subsequently decrementing `outstanding`). The task
+                    // holding the last ticket would have to be *incredibly*, persistently starved
+                    // of execution cycles despite being ready to run for this to ever be remotely
+                    // possible. Given that the tasks consuming tickets would be looping through
+                    // polling for readiness on the socket each time they consumed a ticket, I find
+                    // this case to be impossible enough to not be a worry. Someone may prove me
+                    // wrong in this with a concrete counterexample; if so, I'll happily revise this
+                    // code.
+                    self.pkt_ctx.ticket_info.store(0, Ordering::Relaxed);
+
+                    // SAFETY: `self.packet` internally points to `self.pkt_ctx.pktbuf`, and both
+                    // are mutably accessed by `self.npcap.receive_packet`. Thus, `pktbuf` needs to
+                    // be wrapped by an `UnsafeCell` so that immutability guarantees are opted out
+                    // of (see the documentation to `UnsafeCell`). It is guaranteed that no other
+                    // tasks will have `pktbuf` referenced at this point, as borrows only happen
+                    // while `pkt_ctx.outstanding` > 0 or in this exclusive critical zone.
+                    match unsafe { self.npcap.receive_packet(self.adapter, self.pkt_ctx.packet) } {
+                        false if self.nonblocking.load(Ordering::Relaxed) => {
+                            self.pkt_ctx.outstanding.store(0, Ordering::Relaxed);
+                            return Err(io::Error::last_os_error());
+                        }
+                        false => {
+                            // TODO: check error
+                            let handle = self.read_event_handle();
+                            unsafe {
+                                WaitForSingleObject(handle, INFINITE);
+                            }
+                            // ^ TODO: handle errors from this?
+                        }
+                        true => {
+                            // This scope is necessary to clear `indices`, `pktbuf` references
+                            let range = {
+                                // SAFETY: this section can only be entered by one task at a time, and
+                                // its data mutations are propogated by the subsequent `ticket_start`
+                                // store operation that uses `Ordering::Release`. Other tasks are
+                                // guaranteed not to be accessing `pkt_indices` or `pktbuf` while in this
+                                // section.
+                                let indices = unsafe { &mut *self.pkt_ctx.pkt_indices.get() };
+                                let pktbuf = unsafe { &mut *self.pkt_ctx.pktbuf.get() };
+                                indices.clear();
+
+                                unsafe {
+                                    // Adjust `pktbuf` so that it reflects the last received amount
+                                    let buflen = (*self.pkt_ctx.packet.as_ptr()).ul_bytes_received;
+                                    pktbuf.set_len(buflen as usize);
+                                };
+
+                                let mut rem_buf = pktbuf.as_slice();
+                                let mut pktbuf_idx = 0;
+
+                                while !rem_buf.is_empty() {
+                                    // Parse packet indices one at a time
+
+                                    let Some(hdr_data) = rem_buf.get(..mem::size_of::<BpfHdr>())
+                                    else {
+                                        // TODO: this is really an error
+                                        break;
+                                    };
+
+                                    let (s1, bpf_hdr_slice, s2) =
+                                        unsafe { hdr_data.align_to::<BpfHdr>() };
+                                    debug_assert!(
+                                        s1.is_empty() && bpf_hdr_slice.len() == 1 && s2.is_empty()
+                                    );
+                                    let bpf_hdr = &bpf_hdr_slice[0];
+
+                                    debug_assert!(
+                                        bpf_hdr.bh_hdrlen as usize == mem::size_of::<BpfHdr>()
+                                    );
+                                    if rem_buf.len()
+                                        < bpf_hdr.bh_hdrlen as usize + bpf_hdr.bh_caplen as usize
+                                    {
+                                        // TODO: this is really an error
+                                        break;
+                                    }
+
+                                    indices.push(pktbuf_idx);
+                                    let next_pkt_start = packet_wordalign(
+                                        bpf_hdr.bh_hdrlen as usize + bpf_hdr.bh_caplen as usize,
+                                    );
+
+                                    if rem_buf.len() < next_pkt_start {
+                                        break; // Padding missing--last packet likely reached
+                                    }
+
+                                    rem_buf = &rem_buf[next_pkt_start..];
+                                    pktbuf_idx += next_pkt_start;
+                                }
+
+                                // This task is assigned the first packet
+                                ticket = 0;
+                                indices.len()
+                            };
+                            assert!(range > 0);
+
+                            // storing some value > 0 to outstanding => other tasks still won't be
+                            // able to get into this critical section
+                            self.pkt_ctx.outstanding.store(range, Ordering::Relaxed);
+
+                            // Synchronize following reads/writes to `pkt_indices` and `pktbuf`
+                            // Now other tasks can begin to read packets from the updated buffer
+                            self.pkt_ctx
+                                .ticket_info
+                                .store((1u64 << 32) | (range as u64), Ordering::Release);
+
+                            break;
+                        }
+                    }
+                },
+                Err(_) => return Err(io::ErrorKind::WouldBlock.into()),
+            }
         }
 
-        loop {
-            match unsafe { self.npcap.receive_packet(self.adapter, self.packet) } {
-                false if self.nonblocking => return Err(io::Error::last_os_error()),
-                false => (), // TODO: check error
-                true => return Ok(packet.len()),
-            }
+        // This scope is necessary to clear `indices`, `pktbuf` references
+        let written = {
+            let indices = unsafe { &*self.pkt_ctx.pkt_indices.get() };
+            let pktbuf = unsafe { &*self.pkt_ctx.pktbuf.get() };
 
-            let handle = self.read_event_handle();
-            unsafe {
-                WaitForSingleObject(handle, INFINITE);
-            }
-            // ^ TODO: handle errors from this
-        }
+            let pkt_index = indices[ticket];
+            let pkt_data = &pktbuf[pkt_index..];
+
+            // Invariant: pkt_data.len() > mem::size_of::<BpfHdr>()
+            let (hdr_data, payload) = pkt_data.split_at(mem::size_of::<BpfHdr>());
+            let (s1, bpf_hdr_slice, s2) = unsafe { hdr_data.align_to::<BpfHdr>() };
+            debug_assert!(s1.is_empty() && bpf_hdr_slice.len() == 1 && s2.is_empty());
+            let bpf_hdr = &bpf_hdr_slice[0];
+
+            debug_assert!(bpf_hdr.bh_hdrlen as usize == mem::size_of::<BpfHdr>());
+            let payload = &payload[..bpf_hdr.bh_caplen as usize];
+
+            let written = cmp::min(buf.len(), payload.len());
+            buf.copy_from_slice(&payload[..written]);
+            written
+        };
+
+        // This is `Ordering::Release` so that
+        self.pkt_ctx.outstanding.fetch_sub(1, Ordering::Relaxed);
+
+        Ok(written)
     }
 
     /// Configures the number of times a packet written to the interface via `send()` will b
     /// repeated.
-    pub fn set_repeat_send(&mut self, num_repeats: u32) -> io::Result<()> {
+    pub fn set_repeat_send(&self, num_repeats: u32) -> io::Result<()> {
         let num_repeats =
             libc::c_int::try_from(num_repeats).map_err(|_| io::ErrorKind::InvalidInput)?;
 
@@ -313,22 +508,34 @@ impl NpcapAdapter {
     }
 
     /// Sends a datagram over the socket. On success, returns the number of bytes written.
-    pub fn send(&mut self, packet: &[u8]) -> io::Result<usize> {
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        let packet = match unsafe { self.npcap.allocate_packet() } {
+            None => return Err(io::ErrorKind::OutOfMemory.into()),
+            Some(p) => p,
+        };
+
         // Safety: this casts a `*const u8` into a `*mut u8`. `npcap.init_packet()` uses this
         // buffer without modifying its contents, so this is sound; the C API simply neglects
         // to specify that the buffer pointer is const, so it requires a `*mut u8` as input.
-        let buf = unsafe { NonNull::new_unchecked(packet.as_ptr().cast_mut()) };
+        let data = unsafe { NonNull::new_unchecked(buf.as_ptr().cast_mut()) };
         // Safety: `init_packet()` is called within a `&mut self` context, so `self.packet` is
         // exclusively accessed at this point.
         unsafe {
-            self.npcap.init_packet(self.packet, buf, packet.len());
+            self.npcap.init_packet(packet, data, buf.len());
         }
 
+        // Safety: `send_packet()` is thread-safe so long as `Packet`s are not shared.
         // BUG: this technically blocks regardless of blocking/nonblocking mode.
         // This is an issue in npcap that will require an API addition to resolve.
-        match unsafe { self.npcap.send_packet(self.adapter, self.packet) } {
+        let res = unsafe { self.npcap.send_packet(self.adapter, packet) };
+
+        unsafe {
+            self.npcap.free_packet(packet);
+        }
+
+        match res {
             false => return Err(io::Error::last_os_error()),
-            true => Ok(packet.len()),
+            true => Ok(buf.len()), // TODO: can truncation occur? Is it silent?
         }
     }
 
@@ -352,7 +559,7 @@ impl NpcapAdapter {
     /// Sets the value of the read timeout associated with the socket.
     ///
     /// `timeout` indicates how long the socket will wait to receive a packet before returning.
-    pub fn set_timeout(&mut self, timeout: NpcapTimeout) -> io::Result<()> {
+    pub fn set_timeout(&self, timeout: NpcapTimeout) -> io::Result<()> {
         let timeout = match timeout {
             NpcapTimeout::None => -1,
             NpcapTimeout::Immediate => 0,

--- a/rscap/src/npcap/dll.rs
+++ b/rscap/src/npcap/dll.rs
@@ -23,6 +23,8 @@ use windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE;
 use windows_sys::Win32::System::Threading::CRITICAL_SECTION;
 use windows_sys::Win32::System::IO::OVERLAPPED;
 
+use std::mem;
+
 use crate::filter::BpfInstruction;
 
 // pub const PACKET_MODE_CAPT: libc::c_int = 0x00;
@@ -31,12 +33,10 @@ use crate::filter::BpfInstruction;
 // pub const PACKET_MODE_DUMP: libc::c_int = 0x10;
 // pub const PACKET_MODE_STAT_DUMP: libc::c_int = PACKET_MODE_DUMP | PACKET_MODE_STAT;
 
-/*
 pub const PACKET_ALIGNMENT: usize = mem::size_of::<libc::c_int>();
 pub const fn packet_wordalign(x: usize) -> usize {
     (x + (PACKET_ALIGNMENT - 1)) & !(PACKET_ALIGNMENT - 1)
 }
-*/
 
 // pub const NDIS_MEDIUM_NULL: i32 = -1;
 // pub const NDIS_MEDIUM_CHDLC: i32 = -2;
@@ -89,10 +89,10 @@ pub struct BpfStat {
 #[allow(unused)]
 #[repr(C)]
 pub struct BpfHdr {
-    pub bh_tstamp: libc::timeval,
-    pub bh_caplen: libc::c_uint,
-    pub bh_datalen: libc::c_uint,
-    pub bh_hdrlen: libc::c_ushort,
+    pub bh_tstamp: libc::timeval,  // Seconds since Jan 1, 1970 (+ usec)
+    pub bh_caplen: libc::c_uint,   // truncated length
+    pub bh_datalen: libc::c_uint,  // total length that would have been captured
+    pub bh_hdrlen: libc::c_ushort, // the length of the header that encapsulates the packet (e.g. sizeof(BpfHdr))
 }
 
 #[allow(unused)]

--- a/rscap/src/sniffer.rs
+++ b/rscap/src/sniffer.rs
@@ -144,7 +144,7 @@ impl Sniffer {
     /// of kind [`io::ErrorKind::WouldBlock`] if the socket is unable to immediately send or receive
     /// a packet.
     #[inline]
-    pub fn nonblocking(&mut self) -> io::Result<bool> {
+    pub fn nonblocking(&self) -> io::Result<bool> {
         self.inner.nonblocking()
     }
 
@@ -154,7 +154,7 @@ impl Sniffer {
     /// of kind [`io::ErrorKind::WouldBlock`] if the socket is unable to immediately send or receive
     /// a packet.
     #[inline]
-    pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.inner.set_nonblocking(nonblocking)
     }
 
@@ -166,8 +166,8 @@ impl Sniffer {
     /// A `Sniffer` does not need to be activated (see [`activate()`](Self::activate)) to send
     /// packets.
     #[inline]
-    pub fn send(&mut self, packet: &[u8]) -> io::Result<usize> {
-        self.inner.send(packet)
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.send(buf)
     }
 
     // TODO: `sendmsg`, `recvmsg` implementations that return additional data
@@ -178,7 +178,7 @@ impl Sniffer {
     /// prior to first activating the `Sniffer` via a call to [`activate()`](Self::activate) will
     /// fail with an error of kind [`io::ErrorKind::NotConnected`].
     #[inline]
-    pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.recv(buf)
     }
 


### PR DESCRIPTION
Npcap uses memory-mapped packets for read operations. This PR implements a thread-safe nonblocking algorithm that allows tasks to read distinct packets in the memory-mapped region synchronously. As a side-effect, this enables us to have `send()`/`recv()` operations to operate on `&self` rather than `&mut self`, which will pave the way for async runtime support.