### PR TITLE
Add async support for `async-std`, `mio`, `smol`, `tokio`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -27,15 +27,39 @@ done
 
 case "${OS}" in
     windows*)
-        cargo test
+        cargo test --all-targets
 
-        cargo test --features npcap
+        cargo test --all-targets --features npcap
 
-        cargo test --features npcap-runtime
+        cargo test --all-targets --features npcap-runtime
+
+        cargo test --all-targets --features async-std
+
+        cargo test --all-targets --features smol
+
+        cargo test --all-targets --features tokio
+        
+        cargo test --all-targets --all-features
+
+        # doc tests must have all features enabled to run
+        cargo test --doc --all-features
         ;;
     *)
         # No extra features in any platform other than windows
 
-        cargo test
+        cargo test --all-targets
+
+        cargo test --all-targets --features async-std
+
+        cargo test --all-targets --features mio
+
+        cargo test --all-targets --features smol
+
+        cargo test --all-targets --features tokio
+
+        cargo test --all-targets --all-features
+
+        # doc tests must have all features enabled to run
+        cargo test --doc --all-features
         ;;
 esac

--- a/rscap/Cargo.toml
+++ b/rscap/Cargo.toml
@@ -17,6 +17,11 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+async-std = ["dep:async-io", "dep:async-std"]
+mio = ["dep:mio"]
+smol = ["dep:async-io", "dep:smol"]
+tokio = ["dep:tokio"]
+
 # Enables use of the npcap driver on Windows systems when the necessary dll libraries are present.
 # 
 # If `Packet.dll` is not present on the system, this option will gracefully return runtime errors
@@ -40,3 +45,9 @@ libc = { version = "0.2" }
 once_cell = { version = "1.19" }
 pkts-common = { version = "0.1.0" }
 windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_System_IO", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
+
+async-io = { version = "2.3.4", optional = true }
+async-std = { version = "1.13.0", optional = true }
+mio = { version = "0.8.11", features = ["net"], optional = true }
+smol = { version = "2.0.2", optional = true }
+tokio = { version = "1.38.1", features = ["net", "rt", "time"], optional = true }

--- a/rscap/src/async_std.rs
+++ b/rscap/src/async_std.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+mod sniffer;
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+pub use sniffer::AsyncSniffer;

--- a/rscap/src/bpf.rs
+++ b/rscap/src/bpf.rs
@@ -23,7 +23,7 @@ pub use l2::{RxBlock, RxFrame, RxFrameIter, RxMappedBpf, RxRing};
 
 use std::io;
 #[cfg(not(target_os = "windows"))]
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
 use crate::{filter::PacketFilter, Interface};
 
@@ -117,6 +117,13 @@ impl SnifferImpl {
 impl AsRawFd for SnifferImpl {
     fn as_raw_fd(&self) -> RawFd {
         self.bpf.as_raw_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for SnifferImpl {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.bpf.as_fd()
     }
 }
 

--- a/rscap/src/bpf/l2.rs
+++ b/rscap/src/bpf/l2.rs
@@ -11,9 +11,7 @@
 use std::ffi::{CString, OsStr};
 use std::mem;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
-#[cfg(unix)]
-use std::os::fd::RawFd;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(target_os = "freebsd")]
@@ -742,6 +740,13 @@ impl AsRawFd for Bpf {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.fd
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for Bpf {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
     }
 }
 

--- a/rscap/src/lib.rs
+++ b/rscap/src/lib.rs
@@ -28,6 +28,8 @@
 // Show required OS/features on docs.rs.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+#[cfg(any(doc, feature = "async-std"))]
+pub mod async_std;
 #[cfg(any(
     doc,
     target_os = "dragonfly",
@@ -37,6 +39,12 @@
     target_os = "openbsd",
 ))]
 pub mod bpf;
+#[cfg(any(doc, all(feature = "mio", not(target_os = "windows"))))]
+pub mod mio;
+#[cfg(any(doc, feature = "smol"))]
+pub mod smol;
+#[cfg(any(doc, feature = "tokio"))]
+pub mod tokio;
 // #[cfg(any(target_os = "illumos", target_os = "solaris"))]
 // pub mod dlpi;
 pub mod filter;

--- a/rscap/src/linux.rs
+++ b/rscap/src/linux.rs
@@ -23,7 +23,7 @@ use l2::{L2MappedSocket, L2Socket};
 use mapped::{BlockConfig, RxFrame};
 
 #[cfg(not(target_os = "windows"))]
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::{cmp, io};
 
 use crate::{filter::PacketFilter, Interface};
@@ -470,6 +470,13 @@ impl SnifferImpl {
 impl AsRawFd for SnifferImpl {
     fn as_raw_fd(&self) -> RawFd {
         self.socket.as_raw_fd()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for SnifferImpl {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.socket.as_fd()
     }
 }
 

--- a/rscap/src/linux/l2.rs
+++ b/rscap/src/linux/l2.rs
@@ -11,7 +11,7 @@
 //! Link-layer packet capture/transmission utilities.
 //!
 
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::{io, mem, ptr};
 
 use super::addr::{L2Addr, L2Protocol};
@@ -1154,6 +1154,13 @@ impl AsRawFd for L2Socket {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+impl AsFd for L2Socket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
+    }
+}
+
 /// A link-layer socket with zero-copy packet transmission and reception.
 pub struct L2MappedSocket {
     socket: L2Socket,
@@ -1579,6 +1586,13 @@ impl AsRawFd for L2MappedSocket {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.socket.fd
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+impl AsFd for L2MappedSocket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.socket.fd) }
     }
 }
 

--- a/rscap/src/mio.rs
+++ b/rscap/src/mio.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(any(doc, not(target_os = "windows")))]
+mod sniffer;
+
+#[cfg(any(doc, not(target_os = "windows")))]
+pub use sniffer::AsyncSniffer;

--- a/rscap/src/npcap.rs
+++ b/rscap/src/npcap.rs
@@ -91,3 +91,7 @@ impl SnifferImpl {
         self.adapter.recv(buf)
     }
 }
+
+unsafe impl Send for SnifferImpl {}
+
+unsafe impl Sync for SnifferImpl {}

--- a/rscap/src/npcap/adapter.rs
+++ b/rscap/src/npcap/adapter.rs
@@ -517,7 +517,6 @@ impl NpcapAdapter {
             written
         };
 
-        // This is `Ordering::Release` so that
         self.pkt_ctx.outstanding.fetch_sub(1, Ordering::Relaxed);
 
         Ok(written)

--- a/rscap/src/npcap/adapter.rs
+++ b/rscap/src/npcap/adapter.rs
@@ -302,28 +302,6 @@ impl NpcapAdapter {
 
     /// Receive a datagram from the socket.
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        loop {
-            match self.recv_nonblocking(buf) {
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    // Nonblocking case--return WouldBlock
-                    if self.nonblocking.load(Ordering::Relaxed) {
-                        return Err(e);
-                    }
-
-                    // Blocking case--loop until input received
-                    let handle = self.read_event_handle();
-                    unsafe {
-                        WaitForSingleObject(handle, INFINITE);
-                    }
-                    // ^ TODO: handle errors from WaitForSingleObject?
-                }
-                res => return res,
-            }
-        }
-    }
-
-    /// Receive a datagram from the socket.
-    fn recv_nonblocking(&self, buf: &mut [u8]) -> io::Result<usize> {
         // This method is implemented via a non-trivial number of concurrency operations.
         // It is advisable not to introduce or shuffle ANY code in this method unless you've
         // done thorough analysis of the potential concurrency issues that may arise.
@@ -603,6 +581,10 @@ impl NpcapAdapter {
         }
     }
 }
+
+unsafe impl Send for NpcapAdapter {}
+
+unsafe impl Sync for NpcapAdapter {}
 
 impl Drop for NpcapAdapter {
     fn drop(&mut self) {

--- a/rscap/src/smol.rs
+++ b/rscap/src/smol.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+mod sniffer;
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+pub use sniffer::AsyncSniffer;

--- a/rscap/src/smol/sniffer.rs
+++ b/rscap/src/smol/sniffer.rs
@@ -8,76 +8,69 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(target_os = "windows")]
+use std::borrow::ToOwned;
 use std::io;
-#[cfg(doc)]
-use std::marker::PhantomData;
+#[cfg(target_os = "windows")]
+use std::sync::Arc;
+
 #[cfg(not(target_os = "windows"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use async_io::Async;
 
-#[cfg(target_os = "openbsd")]
-use crate::bpf::RxFrameImpl;
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-use crate::bpf::SnifferImpl;
-/*
-#[cfg(any(target_os = "illumos", target_os = "solaris"))]
-use crate::dlpi::SnifferImpl;
-*/
-#[cfg(target_os = "linux")]
-use crate::linux::{RxFrameImpl, SnifferImpl};
-#[cfg(all(target_os = "windows", feature = "npcap"))]
-use crate::npcap::SnifferImpl;
-use crate::{filter::PacketFilter, Interface};
-// TODO: add pktmon here
+use crate::filter::PacketFilter;
+use crate::{Interface, Sniffer};
 
-// Linux doesn't start capturing packets by default until bind() is called.
-// Both npcap and BPF do.
-// We need to handle this edge case.
+#[cfg(target_os = "windows")]
+#[derive(Clone)]
+struct SnifferWrapper(Arc<Sniffer>);
 
-// BIOCFLUSH - flushes BPF
-// BIOCSETFNR - sets filter without flushing BPF
-// NPF_ResetBufferContents
-//
-// SO_ATTACH_FILTER doesn't flush BPF
+#[cfg(target_os = "windows")]
+impl SnifferWrapper {
+    /// Returns a reference to the underlying `Sniffer` function.
+    fn get_ref(&self) -> &Sniffer {
+        self.0.as_ref()
+    }
 
-/// A device capable of transmitting and receiving arbitrary link-layer (i.e., L2) packets.
-///
-/// This device is specifically capable of transmitting a link-layer packet composed of arbitrary
-/// (including potentially invalid) bytes, as well as receiving all packets passing _in either
-/// direction_ through a given network interface (including those being transmitted by the device
-/// itself).
-pub struct Sniffer {
-    #[cfg(not(doc))]
-    inner: SnifferImpl,
+    /// Returns a reference to the underlying `Sniffer` function.
+    unsafe fn get_mut(&mut self) -> &mut Sniffer {
+        // SAFETY: we never use this within spawn_blocking or similar async contexts
+        Arc::<Sniffer>::get_mut(&mut self.0).unwrap()
+    }
 }
 
-impl Sniffer {
-    /// Creates a new Sniffer instance.
-    ///
-    /// The sniffer will not capture new packets by default until [`activate()`](Self::activate)
-    /// is called.
+/// A cross-platform asynchronous Sniffer interface, suitable for sending/receiving raw packets
+/// over network interfaces in a manner compatible with `smol`.
+pub struct AsyncSniffer {
+    #[cfg(not(target_os = "windows"))]
+    sniffer: Async<Sniffer>,
+    #[cfg(target_os = "windows")]
+    sniffer: SnifferWrapper,
+}
+
+impl AsyncSniffer {
+    /// Creates a new Sniffer for the given interface.
     #[inline]
     pub fn new(iface: Interface) -> io::Result<Self> {
+        Self::new_impl(iface)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl(iface: Interface) -> io::Result<Self> {
+        let sniffer = Sniffer::new(iface)?;
+        sniffer.set_nonblocking(true)?;
+
         Ok(Self {
-            inner: SnifferImpl::new(iface)?,
+            sniffer: Async::new(sniffer)?,
         })
     }
 
-    /// Creates a new sniffer instance using `ring_size` for the size of any zero-copy RX or TX
-    /// rings.
-    ///
-    /// `ring_size` must be a multiple of 524288 (0x80000, or 512 KiB) to work across relevant
-    /// platforms (currently Linux and FreeBSD).
-    #[cfg(any(doc, target_os = "freebsd", target_os = "linux"))]
-    #[inline]
-    pub fn new_with_size(iface: Interface, ring_size: usize) -> io::Result<Self> {
+    #[cfg(target_os = "windows")]
+    fn new_impl(iface: Interface) -> io::Result<Self> {
+        let sniffer = Sniffer::new(iface)?;
+        // Note: nonblocking mode should NOT be set here, as in Windows we spawn a new thread for each send()/recv()
+
         Ok(Self {
-            inner: SnifferImpl::new_with_size(iface, ring_size)?,
+            sniffer: SnifferWrapper(Arc::new(sniffer)),
         })
     }
 
@@ -111,10 +104,7 @@ impl Sniffer {
     /// `activate()` is first called.
     #[inline]
     pub fn activate(&mut self, filter: Option<PacketFilter>) -> io::Result<()> {
-        // This method needs to:
-        // 1. flush the buffer of any pending packets from a previous call to `deactivate()`
-        // 2. Set the BPF to the one provided, or else `ret 1`
-        self.inner.activate(filter)
+        unsafe { self.sniffer.get_mut().activate(filter) }
     }
 
     /// Stops the sniffer from capturing packets.
@@ -133,10 +123,8 @@ impl Sniffer {
     /// available, the behavior and documentation of this method will be updated appropriately.
     ///
     pub fn deactivate(&mut self) -> io::Result<()> {
-        self.inner.deactivate()
+        unsafe { self.sniffer.get_mut().deactivate() }
     }
-
-    // TODO: ^ since Solaris/IllumOS support PF_PACKET, it's actually the case that they *will*
 
     /// Indicates whether nonblocking I/O is enabled or disabled for the given socket.
     ///
@@ -145,7 +133,7 @@ impl Sniffer {
     /// a packet.
     #[inline]
     pub fn nonblocking(&self) -> io::Result<bool> {
-        self.inner.nonblocking()
+        self.sniffer.get_ref().nonblocking()
     }
 
     /// Enables or disables nonblocking I/O for the given socket.
@@ -155,8 +143,10 @@ impl Sniffer {
     /// a packet.
     #[inline]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
-        self.inner.set_nonblocking(nonblocking)
+        self.sniffer.get_ref().set_nonblocking(nonblocking)
     }
+
+    // TODO: `sendmsg`, `recvmsg` implementations that return additional data
 
     /// Send a packet out on the [`Interface`] the `Sniffer` is associated with.
     ///
@@ -166,11 +156,23 @@ impl Sniffer {
     /// A `Sniffer` does not need to be activated (see [`activate()`](Self::activate)) to send
     /// packets.
     #[inline]
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.send(buf)
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
     }
 
-    // TODO: `sendmsg`, `recvmsg` implementations that return additional data
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        self.sniffer.write_with(|inner| inner.send(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        let arc = self.sniffer.clone();
+        let buf = buf.to_owned();
+        async_std::task::spawn_blocking(move || arc.get_ref().send(buf.as_slice())).await
+    }
 
     /// Receive a packet from the [`Interface`] the `Sniffer` is listening on.
     ///
@@ -178,66 +180,36 @@ impl Sniffer {
     /// prior to first activating the `Sniffer` via a call to [`activate()`](Self::activate) will
     /// fail with an error of kind [`io::ErrorKind::NotConnected`].
     #[inline]
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.recv(buf)
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
     }
 
-    /// Receive a zero-copy packet from the [`Interface`] the `Sniffer` is listening on.
-    ///
-    /// The `Sniffer` must be activated prior to receiving packets. Any attempt to receive a packet
-    /// prior to first activating the `Sniffer` via a call to [`activate()`](Self::activate) will
-    /// fail with an error of kind [`io::ErrorKind::NotConnected`].
-    #[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-    #[inline]
-    pub fn mapped_recv(&mut self) -> Option<RxFrame<'_>> {
-        Some(RxFrame {
-            inner: self.inner.mapped_recv()?,
+    #[cfg(not(target_os = "windows"))]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.sniffer.read_with(|inner| inner.recv(buf)).await
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // Prepare to share ownership of `Sniffer` with a blocking thread
+        let arc = self.sniffer.clone();
+        let buflen = buf.len();
+
+        // Run `recv()` in a blocking thread
+        let (res, data) = async_std::task::spawn_blocking(move || {
+            let mut buf = vec![0; buflen];
+            let res = arc.get_ref().recv(buf.as_mut_slice());
+            (res, buf)
         })
+        .await;
+
+        // Copy data output from the blocking thread to `buf`
+        match res {
+            Ok(len) => {
+                buf[..len].copy_from_slice(&data[..len]);
+                Ok(len)
+            }
+            err => err,
+        }
     }
-}
-
-#[cfg(not(target_os = "windows"))]
-impl AsRawFd for Sniffer {
-    #[inline]
-    fn as_raw_fd(&self) -> RawFd {
-        self.inner.as_raw_fd()
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-impl AsFd for Sniffer {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.inner.as_fd()
-    }
-}
-
-/// A packet frame holding a single received zero-copy packet.
-#[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-pub struct RxFrame<'a> {
-    #[cfg(not(doc))]
-    inner: RxFrameImpl<'a>,
-    #[cfg(doc)]
-    _phantom: PhantomData<&'a ()>,
-}
-
-#[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-impl RxFrame<'_> {
-    /// A slice to the underlying zero-copy packet.
-    ///
-    /// Once a packet is finished with, simply dropping the `RxFrame` will lead to the packet frame
-    /// being correctly marked for the kernel to use for future packets.
-    pub fn data(&self) -> &[u8] {
-        self.inner.data()
-    }
-
-    /// A mutable slice to the underlying zero-copy packet.
-    ///
-    /// Any desired modifications may be performed on the packet safely; once a packet is finished
-    /// with, simply dropping the `RxFrame` will lead to the packet frame being correctly marked
-    /// for the kernel to use for future packets.
-    pub fn data_mut(&mut self) -> &mut [u8] {
-        self.inner.data_mut()
-    }
-
-    // TODO: any way to unify `bpf_ts` and the PACKET_RX_RING timestamps??
 }

--- a/rscap/src/tokio.rs
+++ b/rscap/src/tokio.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Copyright (c) 2025 Nathaniel Bennett <me[at]nathanielbennett[dotcom]>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+mod sniffer;
+
+#[cfg(any(doc, not(target_os = "windows"), feature = "npcap"))]
+pub use sniffer::AsyncSniffer;

--- a/rscap/src/tokio/sniffer.rs
+++ b/rscap/src/tokio/sniffer.rs
@@ -8,76 +8,70 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(target_os = "windows")]
+use std::borrow::ToOwned;
 use std::io;
-#[cfg(doc)]
-use std::marker::PhantomData;
+#[cfg(target_os = "windows")]
+use std::sync::Arc;
+
+use crate::filter::PacketFilter;
+use crate::{Interface, Sniffer};
+
 #[cfg(not(target_os = "windows"))]
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use tokio::io::unix::AsyncFd;
 
-#[cfg(target_os = "openbsd")]
-use crate::bpf::RxFrameImpl;
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-use crate::bpf::SnifferImpl;
-/*
-#[cfg(any(target_os = "illumos", target_os = "solaris"))]
-use crate::dlpi::SnifferImpl;
-*/
-#[cfg(target_os = "linux")]
-use crate::linux::{RxFrameImpl, SnifferImpl};
-#[cfg(all(target_os = "windows", feature = "npcap"))]
-use crate::npcap::SnifferImpl;
-use crate::{filter::PacketFilter, Interface};
-// TODO: add pktmon here
+/// A convenience type used to make internal operations consistent between Windows and Unix.
+#[cfg(target_os = "windows")]
+#[derive(Clone)]
+struct SnifferWrapper(Arc<Sniffer>);
 
-// Linux doesn't start capturing packets by default until bind() is called.
-// Both npcap and BPF do.
-// We need to handle this edge case.
+#[cfg(target_os = "windows")]
+impl SnifferWrapper {
+    /// Returns a reference to the underlying `Sniffer` function.
+    fn get_ref(&self) -> &Sniffer {
+        self.0.as_ref()
+    }
 
-// BIOCFLUSH - flushes BPF
-// BIOCSETFNR - sets filter without flushing BPF
-// NPF_ResetBufferContents
-//
-// SO_ATTACH_FILTER doesn't flush BPF
-
-/// A device capable of transmitting and receiving arbitrary link-layer (i.e., L2) packets.
-///
-/// This device is specifically capable of transmitting a link-layer packet composed of arbitrary
-/// (including potentially invalid) bytes, as well as receiving all packets passing _in either
-/// direction_ through a given network interface (including those being transmitted by the device
-/// itself).
-pub struct Sniffer {
-    #[cfg(not(doc))]
-    inner: SnifferImpl,
+    /// Returns a reference to the underlying `Sniffer` function.
+    fn get_mut(&mut self) -> &mut Sniffer {
+        // SAFETY: we never use this within spawn_blocking or similar async contexts
+        Arc::<Sniffer>::get_mut(&mut self.0).unwrap()
+    }
 }
 
-impl Sniffer {
-    /// Creates a new Sniffer instance.
-    ///
-    /// The sniffer will not capture new packets by default until [`activate()`](Self::activate)
-    /// is called.
+/// A cross-platform asynchronous Sniffer interface, suitable for sending/receiving raw packets
+/// over network interfaces in a manner compatible with `tokio`.
+pub struct AsyncSniffer {
+    #[cfg(not(target_os = "windows"))]
+    sniffer: AsyncFd<Sniffer>,
+    #[cfg(target_os = "windows")]
+    sniffer: SnifferWrapper,
+}
+
+impl AsyncSniffer {
+    /// Creates a new Sniffer for the given interface.
     #[inline]
     pub fn new(iface: Interface) -> io::Result<Self> {
+        Self::new_impl(iface)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn new_impl(iface: Interface) -> io::Result<Self> {
+        let sniffer = Sniffer::new(iface)?;
+        sniffer.set_nonblocking(true)?;
+
         Ok(Self {
-            inner: SnifferImpl::new(iface)?,
+            sniffer: AsyncFd::new(sniffer)?,
         })
     }
 
-    /// Creates a new sniffer instance using `ring_size` for the size of any zero-copy RX or TX
-    /// rings.
-    ///
-    /// `ring_size` must be a multiple of 524288 (0x80000, or 512 KiB) to work across relevant
-    /// platforms (currently Linux and FreeBSD).
-    #[cfg(any(doc, target_os = "freebsd", target_os = "linux"))]
-    #[inline]
-    pub fn new_with_size(iface: Interface, ring_size: usize) -> io::Result<Self> {
+    #[cfg(target_os = "windows")]
+    fn new_impl(iface: Interface) -> io::Result<Self> {
+        let sniffer = Sniffer::new(iface)?;
+        // Note: nonblocking mode should NOT be set here, as in Windows we spawn a new thread for each send()/recv()
+
         Ok(Self {
-            inner: SnifferImpl::new_with_size(iface, ring_size)?,
+            sniffer: SnifferWrapper(Arc::new(sniffer)),
         })
     }
 
@@ -111,10 +105,7 @@ impl Sniffer {
     /// `activate()` is first called.
     #[inline]
     pub fn activate(&mut self, filter: Option<PacketFilter>) -> io::Result<()> {
-        // This method needs to:
-        // 1. flush the buffer of any pending packets from a previous call to `deactivate()`
-        // 2. Set the BPF to the one provided, or else `ret 1`
-        self.inner.activate(filter)
+        self.sniffer.get_mut().activate(filter)
     }
 
     /// Stops the sniffer from capturing packets.
@@ -133,10 +124,8 @@ impl Sniffer {
     /// available, the behavior and documentation of this method will be updated appropriately.
     ///
     pub fn deactivate(&mut self) -> io::Result<()> {
-        self.inner.deactivate()
+        self.sniffer.get_mut().deactivate()
     }
-
-    // TODO: ^ since Solaris/IllumOS support PF_PACKET, it's actually the case that they *will*
 
     /// Indicates whether nonblocking I/O is enabled or disabled for the given socket.
     ///
@@ -145,7 +134,7 @@ impl Sniffer {
     /// a packet.
     #[inline]
     pub fn nonblocking(&self) -> io::Result<bool> {
-        self.inner.nonblocking()
+        self.sniffer.get_ref().nonblocking()
     }
 
     /// Enables or disables nonblocking I/O for the given socket.
@@ -155,8 +144,10 @@ impl Sniffer {
     /// a packet.
     #[inline]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
-        self.inner.set_nonblocking(nonblocking)
+        self.sniffer.get_ref().set_nonblocking(nonblocking)
     }
+
+    // TODO: `sendmsg`, `recvmsg` implementations that return additional data
 
     /// Send a packet out on the [`Interface`] the `Sniffer` is associated with.
     ///
@@ -166,11 +157,30 @@ impl Sniffer {
     /// A `Sniffer` does not need to be activated (see [`activate()`](Self::activate)) to send
     /// packets.
     #[inline]
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.send(buf)
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.send_impl(buf).await
     }
 
-    // TODO: `sendmsg`, `recvmsg` implementations that return additional data
+    #[cfg(not(target_os = "windows"))]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.sniffer.readable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().send(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[inline]
+    async fn send_impl(&self, buf: &[u8]) -> io::Result<usize> {
+        let arc = self.sniffer.clone();
+        let buf = buf.to_owned();
+        tokio::task::spawn_blocking(move || arc.get_ref().send(buf.as_slice())).await?
+    }
 
     /// Receive a packet from the [`Interface`] the `Sniffer` is listening on.
     ///
@@ -178,66 +188,43 @@ impl Sniffer {
     /// prior to first activating the `Sniffer` via a call to [`activate()`](Self::activate) will
     /// fail with an error of kind [`io::ErrorKind::NotConnected`].
     #[inline]
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.recv(buf)
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_impl(buf).await
     }
 
-    /// Receive a zero-copy packet from the [`Interface`] the `Sniffer` is listening on.
-    ///
-    /// The `Sniffer` must be activated prior to receiving packets. Any attempt to receive a packet
-    /// prior to first activating the `Sniffer` via a call to [`activate()`](Self::activate) will
-    /// fail with an error of kind [`io::ErrorKind::NotConnected`].
-    #[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-    #[inline]
-    pub fn mapped_recv(&mut self) -> Option<RxFrame<'_>> {
-        Some(RxFrame {
-            inner: self.inner.mapped_recv()?,
+    #[cfg(not(target_os = "windows"))]
+    async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.sniffer.readable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().recv(buf)) {
+                Ok(result) => return result,
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn recv_impl(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // Prepare to share ownership of `Sniffer` with a blocking thread
+        let arc = self.sniffer.clone();
+        let buflen = buf.len();
+
+        // Run `recv()` in a blocking thread
+        let (res, data) = tokio::task::spawn_blocking(move || {
+            let mut buf = vec![0; buflen];
+            let res = arc.get_ref().recv(buf.as_mut_slice());
+            (res, buf)
         })
+        .await?;
+
+        // Copy data output from the blocking thread to `buf`
+        match res {
+            Ok(len) => {
+                buf[..len].copy_from_slice(&data[..len]);
+                Ok(len)
+            }
+            err => err,
+        }
     }
-}
-
-#[cfg(not(target_os = "windows"))]
-impl AsRawFd for Sniffer {
-    #[inline]
-    fn as_raw_fd(&self) -> RawFd {
-        self.inner.as_raw_fd()
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-impl AsFd for Sniffer {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.inner.as_fd()
-    }
-}
-
-/// A packet frame holding a single received zero-copy packet.
-#[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-pub struct RxFrame<'a> {
-    #[cfg(not(doc))]
-    inner: RxFrameImpl<'a>,
-    #[cfg(doc)]
-    _phantom: PhantomData<&'a ()>,
-}
-
-#[cfg(any(doc, target_os = "linux", target_os = "freebsd"))]
-impl RxFrame<'_> {
-    /// A slice to the underlying zero-copy packet.
-    ///
-    /// Once a packet is finished with, simply dropping the `RxFrame` will lead to the packet frame
-    /// being correctly marked for the kernel to use for future packets.
-    pub fn data(&self) -> &[u8] {
-        self.inner.data()
-    }
-
-    /// A mutable slice to the underlying zero-copy packet.
-    ///
-    /// Any desired modifications may be performed on the packet safely; once a packet is finished
-    /// with, simply dropping the `RxFrame` will lead to the packet frame being correctly marked
-    /// for the kernel to use for future packets.
-    pub fn data_mut(&mut self) -> &mut [u8] {
-        self.inner.data_mut()
-    }
-
-    // TODO: any way to unify `bpf_ts` and the PACKET_RX_RING timestamps??
 }


### PR DESCRIPTION
Add async support for all four major async runtimes. This specifically implements a new `AsyncSniffer` type that is analogous to `Sniffer` in non-async contexts.